### PR TITLE
Add minimal files to be able to run this application in a docker container

### DIFF
--- a/99-custom-php.ini
+++ b/99-custom-php.ini
@@ -1,0 +1,7 @@
+# Add configuration to fix an issue where the `generate_all.php` script was outputting
+# `Content-type: text/html` instead of `Content-type: application/zip`:
+
+# - Recognize short opening tags, which are used in this project's php files.
+short_open_tag = On
+# - Enable output buffering.
+output_buffering = On

--- a/99-custom-php.ini
+++ b/99-custom-php.ini
@@ -5,3 +5,6 @@
 short_open_tag = On
 # - Enable output buffering.
 output_buffering = On
+
+# Fake our SERVER_NAME so common.php will execute the correct logic for rgb color parsing.
+auto_prepend_file = "/var/www/html/server_name_override.php"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Doc: https://hub.docker.com/_/php/
+FROM php:8.4.3-apache
+
+RUN apt-get update && apt-get install -y \
+    libpng-dev \
+    zip \
+    libzip-dev \
+    && docker-php-ext-configure gd \
+    && docker-php-ext-install gd zip
+
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+# Use our minimal custom php conf to support some legacy behavior.
+COPY 99-custom-php.ini "$PHP_INI_DIR/conf.d"
+
+COPY . /var/www/html/
+
+# Grant write permissions to /var/www/html to www-data, because
+# the application writes temporary files to /var/www/html/generated/
+RUN chown -R www-data:www-data /var/www/html && chmod -R 755 /var/www/html
+
+# Enable logs specified in log4php.xml
+RUN mkdir -p /home/vdl/logs/android-holo-colors
+RUN chown -R www-data:www-data /home/vdl/logs && chmod -R 775 /home/vdl/logs
+
+EXPOSE 80
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+# Run the application with:
+#
+#     docker-compose up --build
+#
+# Then access it at http://localhost:8088/
+
+services:
+  web:
+    build: .
+    ports:
+      - "8088:80"
+

--- a/server_name_override.php
+++ b/server_name_override.php
@@ -1,0 +1,3 @@
+<?php
+$_SERVER['SERVER_NAME'] = 'www.android-holo-colors.com';
+?>


### PR DESCRIPTION
**Note**: I realize this repository is legacy. I was just looking at it for nostalgic reasons 😅 Was cool to see it running again in docker.

--- 

* Add a missing `database.php` file which is referenced by `generate_all.php`.
* Add a minimal `php.ini` file to fix an issue where the `generate_all.php` script was outputing `Content-type: text/html` instead of `Content-type: application/zip`:
  - Recognize short opening tags, which are used in this project's php files.
  - Enable output buffering.
* Add a docker configuration to be able to run the application in a docker container.

Run the application with:

     docker-compose up --build

Then access it at http://localhost:8088/